### PR TITLE
client: allow arbitrary values in json

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,8 +4,8 @@
   :license {:name "MIT License"}
   :profiles {:dev {:global-vars {*warn-on-reflection* true}}}
   :dependencies [[org.clojure/clojure "1.9.0"]
-                 [spootnik/net        "0.3.3-beta24"]
-                 [cheshire            "5.8.0"]
+                 [aleph               "0.4.4"]
+                 [metosin/jsonista    "0.2.1"]
                  [org.flatland/useful "0.11.5"]]
   :plugins [[lein-cljfmt "0.5.7"]]
   :test-selectors {:default (complement :integration-test)

--- a/src/raven/client.clj
+++ b/src/raven/client.clj
@@ -284,8 +284,7 @@
     ;; it fails).
     (http/post (format "%s/api/store/" uri)
                {:headers {"X-Sentry-Auth"  (auth-header ts key sig)
-                          "Content-Type"   "application/json; charset=utf-8"
-                          "Content-Length" (count json-payload)}
+                          "Content-Type"   "application/json"}
                 :body    json-payload})))
 
 (defn capture!


### PR DESCRIPTION
relying on cheshire forces us into dirty consumer-tricks to
avoid serialization related capture failures.

JSONista defaults to toString for unknown values, let's rely
on that. If necessary, JSONista also allows custom encoders
at serialization time, whereas Cheshire considers them project
wide.

While there, switch to aleph which is becoming our de-facto http client.
This addresses #28 