### PR TITLE
Cleanup after move to aleph.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,16 +32,6 @@ The `capture!` function returns the Sentry Event ID.
   that omitting this parameter will make use of some thread-local storage for
   some of the functionality.
 
-#### Passing your own http instance
-
-In many cases, it makes sense to reuse an already existing http client (created
-with http/build-client). Raven will reuse an http instance if it is passed to
-the (capture!) function through the `context` parameter, as :http.
-
-```clojure
-(capture! {:http (http/build-client {})} "<dsn>" "My message")
-```
-
 ### Extra interfaces
 
 #### Tags

--- a/TODO.md
+++ b/TODO.md
@@ -5,10 +5,7 @@ prove useful.
 In no particular order of importance:
 
 - Refactor the source code in several clojure files
-- Use aleph instead of net (in order to allow injecting an aleph connection pool
-  instead of a net/client)
 - Offer a top-level BYON (bring your own networking) function, returning a well
   formatted ring client request map.
-- Offer a top level function to add an exception+stacktrace to a context map
-  like `(add-exception! context throwable)`. This allows us to compose functions
-  better.
+- Allows passing an aleph connection pool to use via context (instead of
+  defaulting to aleph's default connection pool).

--- a/test/raven/client_test.clj
+++ b/test/raven/client_test.clj
@@ -156,6 +156,11 @@
     (let [context {:breadcrumbs [(make-breadcrumb! (:message expected-breadcrumb) (:category expected-breadcrumb) (:level expected-breadcrumb) frozen-ts)]}]
       (is (= expected-breadcrumb (first (:values (:breadcrumbs (make-test-payload context)))))))))
 
+(deftest no-http-client-in-context
+  (testing "unused keys in context don't end up in payload"
+    (let [context {:http_client "something"}]
+      (is (= nil (:http_client (make-test-payload context)))))))
+
 (deftest add-user
   (testing "user is added to the payload"
     (add-user! (make-user expected-user-id))


### PR DESCRIPTION
Unfortunately the move to aleph made the injection of http client not
work anymore.

This changes the docs and ensures passing an http client anyway won't
break anything.