### PR TITLE
Feature/add alpeh connection pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,14 @@ The `capture!` function returns the Sentry Event ID.
   that omitting this parameter will make use of some thread-local storage for
   some of the functionality.
 
-#### Passing your own http instance
+#### Passing your own aleph connection pool
 
-In many cases, it makes sense to reuse an already existing http client (created
-with http/build-client). Raven will reuse an http instance if it is passed to
-the (capture!) function through the `context` parameter, as :http.
+In many cases, it makes sense to reuse an already existing aleph conneciton pool (created
+with http/connection-pool). Raven will reuse a connection pool if it is passed to
+the (capture!) function through the `context` parameter, as `:pool`.
 
 ```clojure
-(capture! {:http (http/build-client {})} "<dsn>" "My message")
+(capture! {:pool (http/connection-pool {:connection-options {:raw-stream? true}})} "<dsn>" "My message")
 ```
 
 ### Extra interfaces

--- a/src/raven/client.clj
+++ b/src/raven/client.clj
@@ -162,7 +162,7 @@
 
 (defn add-breadcrumbs-to-payload
   [context payload]
-  (let [breadcrumbs-list (:breadcrumbs context)]
+  (let [breadcrumbs-list (or (:breadcrumbs payload) (:breadcrumbs context))]
     (cond-> payload (seq breadcrumbs-list) (assoc :breadcrumbs {:values breadcrumbs-list}))))
 
 (defn add-user-to-payload

--- a/src/raven/client.clj
+++ b/src/raven/client.clj
@@ -291,9 +291,11 @@
     ;; event makes it to the sentry server or not (we certainly don't want to block until
     ;; it fails).
     (http/post (format "%s/api/store/" uri)
-               {:headers {"X-Sentry-Auth"  (auth-header ts key sig)
-                          "Content-Type"   "application/json"}
-                :body    json-payload})))
+               (merge {:headers {"X-Sentry-Auth"  (auth-header ts key sig)
+                                 "Content-Type"   "application/json"}
+                       :body    json-payload}
+                      (cond (contains? context :pool) {:pool (:pool context)}
+                            :else {})))))
 
 (defn capture!
   "Send a capture over the network. If `ev` is an exception,

--- a/test/raven/client_test.clj
+++ b/test/raven/client_test.clj
@@ -156,6 +156,12 @@
     (let [context {:breadcrumbs [(make-breadcrumb! (:message expected-breadcrumb) (:category expected-breadcrumb) (:level expected-breadcrumb) frozen-ts)]}]
       (is (= expected-breadcrumb (first (:values (:breadcrumbs (make-test-payload context)))))))))
 
+(deftest multi-breadcrumbs-in-manual-context
+  (testing "multiple breadcrumbs are sent using a manual context."
+    (let [context {:breadcrumbs [(make-breadcrumb! (:message expected-breadcrumb) (:category expected-breadcrumb) (:level expected-breadcrumb) frozen-ts) (make-breadcrumb! (:message expected-breadcrumb) (:category expected-breadcrumb))]}]
+      (is (= expected-breadcrumb (first (:values (:breadcrumbs (make-test-payload context))))))
+      (is (= 2 (count (:values (:breadcrumbs (make-test-payload context)))))))))
+
 (deftest add-user
   (testing "user is added to the payload"
     (add-user! (make-user expected-user-id))

--- a/test/raven/integration_test.clj
+++ b/test/raven/integration_test.clj
@@ -1,6 +1,7 @@
 (ns raven.integration-test
   (:require [clojure.test :refer :all]
-            [raven.client :refer :all]))
+            [raven.client :refer :all]
+            [aleph.http :refer [default-connection-pool]]))
 
 (def http-info-map
   (make-http-info "http://example.com" "POST" {:Content-Type "text/html"} "somekey=somevalue" "somecookie=somevalue" "some POST data. This might be BIG!" {:some-env "a value"}))
@@ -18,8 +19,22 @@
     (add-breadcrumb! (make-breadcrumb! "The user did something else" "category.1"))
     (add-breadcrumb! (make-breadcrumb! "The user did something bad" "category.2" "error"))
     (add-user! (make-user "123456" "huginn@example.com" "127.0.0.1" "Huginn"))
+    (add-tag! :integration-test-pool "default")
+    (add-tag! :integration-test-context "thread-local")
     (add-http-info! http-info-map)
     (capture! (get-dsn) (Exception. "Test exception") {:arbitrary-tag "arbitrary-value"})
+    ;; We sleep for a second since otherwise the process dies before the request had time to fly out
+    ;; to sentry (since it's asynchronous and therefore doesn't block the main thread).
+    (Thread/sleep 1000)))
+
+(deftest ^:integration-test raven-integration-test-explicit-pool
+  (testing "Sending out a test sentry entry using an explicit context and explcit pool"
+    (capture! {:pool default-connection-pool} (get-dsn) (-> {}
+                                                            (add-user! (make-user "654321" "muninn@example.com" "127.1.1.1" "Muninn"))
+                                                            (add-http-info! http-info-map)
+                                                            (add-exception! (Exception. "Another test exception"))) {:integration-test-pool "explicit"
+                                                                                                                     :integration-test-context "explicit"})
+
     ;; We sleep for a second since otherwise the process dies before the request had time to fly out
     ;; to sentry (since it's asynchronous and therefore doesn't block the main thread).
     (Thread/sleep 1000)))


### PR DESCRIPTION
This branch allows users to inject an aleph connection pool via the context, as was possible for the previous implementation (it used to be possible to inject http clients but that was lost when we moved to using aleph).

It also fixes a drive-by bug when adding breadcrumbs via threading.