### PR TITLE
Merge :params into the env dict.

### DIFF
--- a/src/raven/client.clj
+++ b/src/raven/client.clj
@@ -396,8 +396,8 @@
   [request]
   (cond-> {:REMOTE_ADDR  (:remote-addr request)
            :websocket?   (:websocket? request)
-           :route-params (:route-params request)
-           :params (:params request)}
+           :route-params (:route-params request)}
+    (some? (:params request))          (merge (:params request))
     (some? (:compojure/route request)) (assoc :compojure/route (:compojure/route request))
     (some? (:route request))           (assoc :bidi/route (get-in request [:route :handler]))))
 

--- a/test/raven/client_test.clj
+++ b/test/raven/client_test.clj
@@ -248,6 +248,12 @@
     (is (= (:url (:request (first @http-requests-payload-stub))) expected-test-url))
     (is (= (get-in (first @http-requests-payload-stub) [:request :env :compojure/route]) nil))))
 
+(deftest ring-request-with-params
+  (testing "passing a ring request to Sentry when using ring.middleware.params"
+    (add-ring-request! (assoc frozen-request :params {:some-param "value"}))
+    (capture! ":memory:" expected-message)
+    (is (= (:some-param (:env (:request (first @http-requests-payload-stub)))) "value"))))
+
 (deftest ring-request-query-string
   (testing "passing a ring request to Sentry with a query string"
     (add-http-info! (make-ring-request-info (assoc frozen-request :query-string "name=munnin")))


### PR DESCRIPTION
As reported in https://github.com/exoscale/raven/issues/40 Sentry does
not seem to display nested dicts nicely in its http interface.

Since our helper here is advertising to work with ring requests, we
should handle the case of the user using ring.middleware.params
gracefully and make it look as nice as we can. Therefore, we now merge
that dict into the "env" sentry dict, so as to have one nice entry per
item.