### PR TITLE
Make sure we don't pass the :params to sentry.

### DIFF
--- a/src/raven/client.clj
+++ b/src/raven/client.clj
@@ -396,8 +396,7 @@
   [request]
   (cond-> {:REMOTE_ADDR  (:remote-addr request)
            :websocket?   (:websocket? request)
-           :route-params (:route-params request)
-           :params (:params request)}
+           :route-params (:route-params request)}
     (some? (:compojure/route request)) (assoc :compojure/route (:compojure/route request))
     (some? (:route request))           (assoc :bidi/route (get-in request [:route :handler]))))
 

--- a/test/raven/client_test.clj
+++ b/test/raven/client_test.clj
@@ -255,6 +255,12 @@
     (is (= (:url (:request (first @http-requests-payload-stub))) (str expected-test-url "?name=munnin")))
     (is (= (get-in (first @http-requests-payload-stub) [:request :query_string]) "name=munnin"))))
 
+(deftest ring-request-no-params
+  (testing "passing a ring request does not forward :params to sentry"
+    (add-ring-request! (assoc frozen-request :params {:something "blah"}))
+    (capture! ":memory:" expected-message)
+    (is (nil? (:params (:env (:request (first @http-requests-payload-stub))))))))
+
 (deftest no-http-client-in-context
   (testing "unused keys in context don't end up in payload"
     (let [context {:http_client "something"}]


### PR DESCRIPTION
Information in :params (as set by ring.middleware.params) is redundant
and potentially harful to include in the sentry report (it can contain
very large things, or unfiltered API keys etc...).