### PR TITLE
client: always close (discard) the body

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,10 @@ using the `clear-http-stub` convenience function.
 
 ### Changelog
 
+#### 0.4.6
+
+- Close the body netty stream
+
 #### 0.4.5
 
 - add-tags! function to add multiple tags to the context

--- a/project.clj
+++ b/project.clj
@@ -1,11 +1,11 @@
-(defproject exoscale/raven "0.4.5"
+(defproject exoscale/raven "0.4.6-SNAPSHOT"
   :description "clojure sentry client library"
   :url "https://github.com/exoscale/raven"
   :license {:name "MIT License"}
   :profiles {:dev {:global-vars {*warn-on-reflection* true}}}
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [aleph               "0.4.6"]
-                 [metosin/jsonista    "0.2.1"]
+                 [metosin/jsonista    "0.2.2"]
                  [org.flatland/useful "0.11.5"]]
   :test-selectors {:default (complement :integration-test)
                    :integration :integration-test})

--- a/src/raven/client.clj
+++ b/src/raven/client.clj
@@ -304,8 +304,7 @@
                                              :content-type   "application/json;charset=utf-8"}
                          :body              json-payload
                          :throw-exceptions? false}))
-      (d/chain
-        #(.close ^Closeable (:body %))))))
+      #(.close ^Closeable (:body %)))))
 
 (defn capture!
   "Send a capture over the network. If `ev` is an exception,


### PR DESCRIPTION
The goal is to make the HTTP call a real fire'n'forget in case of `raw-stream?` since we don't have any control on the pool.