### PR TITLE
Better extra and tests

### DIFF
--- a/src/raven/client.clj
+++ b/src/raven/client.clj
@@ -424,9 +424,20 @@
   ([context tags]
    (reduce-kv add-tag! context tags)))
 
+(defn add-extra!
+  "Add a map of extra data to the context (or a thread-local storage)
+  preserving its previous keys."
+  ([extra]
+   (swap! @thread-storage add-extra! extra))
+  ([context extra]
+   (update context :extra merge extra)))
+
 (defn add-exception!
   "Add an exception to the context (or a thread-local storage)."
   ([^Throwable e]
    (swap! @thread-storage add-exception! e))
   ([context ^Throwable e]
-   (merge context (e/exception->ev e))))
+   (let [env (e/exception->ev e)]
+     (-> context
+         (merge (dissoc env :extra))
+         (add-extra! (:extra env))))))


### PR DESCRIPTION
Sorry I didn't do that in my previous PR, but still. I found a small issue when adding an exception. An exception carries an `:extra` field which is common and thus should not be replaced but merged. This PR fixes that behaviour. Even if we add an exception, the old extra data will be kept.

Also, there is a separate `add-extra!` function what might be useful for Obwald.

Finally, I covered my recent changes with unit tests.
