### PR TITLE
add safe-map

### DIFF
--- a/src/raven/client.clj
+++ b/src/raven/client.clj
@@ -265,8 +265,7 @@
   map->SafeMap)
 
 (def json-mapper
-  (doto (json/object-mapper {:encoders {SafeMap (fn [x ^JsonGenerator jg] (.writeString jg (pr-str x)))
-                                        EmptyMap (fn [_ ^JsonGenerator jg] (.writeString jg "{}"))}})
+  (doto (json/object-mapper {:encoders {SafeMap (fn [x ^JsonGenerator jg] (.writeString jg (pr-str x)))}})
     (.configure SerializationFeature/FAIL_ON_EMPTY_BEANS false)
     (.configure MapperFeature/AUTO_DETECT_GETTERS false)
     (.configure MapperFeature/AUTO_DETECT_IS_GETTERS false)

--- a/src/raven/client.clj
+++ b/src/raven/client.clj
@@ -1,6 +1,5 @@
 (ns raven.client
   "A netty-based Sentry client."
-  (:require-clojure :exclude [empty])
   (:import java.lang.Throwable
            java.lang.Exception)
   (:require [aleph.http            :as http]

--- a/test/raven/client_test.clj
+++ b/test/raven/client_test.clj
@@ -382,4 +382,7 @@
   (is (= "{\"a\":{\"b\":{}}}"
          (String. (json/write-value-as-bytes {:a (Foo. (java.lang.Exception. "yolo"))}
                                              json-mapper)))
-      "don't do (bean x) on unknown values"))
+      "don't do (bean x) on unknown values")
+  (is (= "\"#<SafeMap[:a, :b]>\""
+         (json/write-value-as-string (safe-map {:a 1 :b 2})
+                                     json-mapper))))


### PR DESCRIPTION
allows to serialize map into string token that hides map values